### PR TITLE
Specify support for crystal >= 0.36.1 in shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -9,6 +9,6 @@ development_dependencies:
     github: crystal-ameba/ameba
     version: ~> 0.14.0
 
-crystal: '>= 0.36.1'
+crystal: ">= 0.36.1"
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -9,6 +9,6 @@ development_dependencies:
     github: crystal-ameba/ameba
     version: ~> 0.14.0
 
-crystal: 0.36.1
+crystal: '>= 0.36.1'
 
 license: MIT


### PR DESCRIPTION
* Updated `shard.yml` to allow support for Crystal 1.0.0
* Enabled GitHub Actions to run the tests on my fork and the [build is green](https://github.com/HashNuke/retriable.cr/actions/runs/974073792)