### PR TITLE
Updates to support crystal 1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Install Crystal
-        uses: oprypin/install-crystal@v1
+        uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{ matrix.crystal }}
 
       - name: Download source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: shards install

--- a/shard.yml
+++ b/shard.yml
@@ -7,8 +7,8 @@ authors:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.2.0
+    version: ~> 1.5
 
-crystal: ~> 1.6
+crystal: ~> 1.9
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: retriable
-version: 0.2.4
+version: 0.2.5
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>


### PR DESCRIPTION
This PR updates `shard.yml` to support Crystal `1.9.x`. Also includes changes to attempt to resolve GitHub Actions warnings.

## Changes

* Bump Crystal to `~> 1.9` and ameba to `~> 1.5` in shard.yml
* Update GitHub Actions config to resolve GitHub Actions warnings
    * Use `crystal-lang/install-crystal@v1`
    * Use `actions/checkout@v3`
* Bump version to `0.2.5` in shard.yml

## Screenshot

*Couldn't trigger the GitHub Actions workflow on my fork despite being enabled. So I've run `shard install` and `crystal spec` with Crystal 1.9 on my machine. Screenshot below.*

![CleanShot 2023-08-21 at 16 28 48@2x](https://github.com/Sija/retriable.cr/assets/84005/fca42a43-425a-4795-8abf-6daceafdbd07)

